### PR TITLE
switch csv delimiters to tsv in output tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse r-cairo r-workflowscriptscommon r-scpred;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse r-cairo r-workflowscriptscommon r-scpred r-dplyr<1;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse r-cairo r-workflowscriptscommon r-scpred r-dplyr<1;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse r-cairo r-workflowscriptscommon r-scpred 'r-dplyr<1';
     fi
 
 install:

--- a/scpred_get_std_output.R
+++ b/scpred_get_std_output.R
@@ -42,7 +42,7 @@ option_list = list(
 )
 
 opt = wsc_parse_args(option_list, mandatory = c("predictions_file", "output_table"))
-data = read.csv(opt$predictions_file, row.names = 1)
+data = read.csv(opt$predictions_file, row.names = 1, sep = "\t")
 if(!is.na(opt$cell_id_col)){
     barcodes = as.character(data[, opt$cell_id_col])
     } else{

--- a/scpred_get_std_output.R
+++ b/scpred_get_std_output.R
@@ -42,7 +42,7 @@ option_list = list(
 )
 
 opt = wsc_parse_args(option_list, mandatory = c("predictions_file", "output_table"))
-data = read.csv(opt$predictions_file, row.names = 1, sep = "\t")
+data = read.csv(opt$predictions_file, row.names = 1)
 if(!is.na(opt$cell_id_col)){
     barcodes = as.character(data[, opt$cell_id_col])
     } else{

--- a/scpred_predict.R
+++ b/scpred_predict.R
@@ -78,7 +78,7 @@ pred_data = readRDS(opt$pred_data)
 # get predictions 
 scp = scPredict(scp, newData = as.matrix(pred_data), threshold = opt$threshold_level)
 predictions = getPredictions(scp)
-write.table(predictions, file=opt$output_path, row.names = TRUE, sep = "\t")
+write.csv(predictions, file=opt$output_path, row.names = TRUE)
 
 # if test labels supplied, run model performance evaluation block 
 if(!is.na(opt$test_labels)){

--- a/scpred_predict.R
+++ b/scpred_predict.R
@@ -78,7 +78,7 @@ pred_data = readRDS(opt$pred_data)
 # get predictions 
 scp = scPredict(scp, newData = as.matrix(pred_data), threshold = opt$threshold_level)
 predictions = getPredictions(scp)
-write.csv(predictions, file=opt$output_path, row.names = TRUE)
+write.table(predictions, file=opt$output_path, row.names = TRUE, sep = "\t")
 
 # if test labels supplied, run model performance evaluation block 
 if(!is.na(opt$test_labels)){


### PR DESCRIPTION
To avoid problems with comma-containing labels, switch to tsv delimiters in output tables. 